### PR TITLE
修改以适应最新Discourse版本

### DIFF
--- a/javascripts/discourse/api-initializers/theme-initializer.gjs
+++ b/javascripts/discourse/api-initializers/theme-initializer.gjs
@@ -1,5 +1,8 @@
-<script type="text/discourse-plugin" version="1.0.0">
-api.decorateCookedElement((elem, helper) => {
+import { apiInitializer } from "discourse/lib/api";
+
+export default apiInitializer((api) => {
+  // Your code here
+  api.decorateCookedElement((elem, helper) => {
     try {
         for (const p of elem.querySelectorAll(":scope > .lightbox-wrapper")) {
             const a = p.querySelector("a.lightbox");
@@ -28,4 +31,4 @@ api.decorateCookedElement((elem, helper) => {
     onlyStream: true,
 });
 
-</script>
+});


### PR DESCRIPTION
感谢原作者的付出，我根据https://meta.discourse.org/t/modernizing-inline-script-tags-for-templates-js-api/366482
对代码进行了微小修改以适应最新的Discourse版本